### PR TITLE
adding cloud function to update followers profile photo when changed

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -264,3 +264,37 @@ exports.onCreateActivity = functions.firestore
                 }
             });
     })
+
+/**
+ * Update photoUrl field on the collection usuarios_seguindo of each politic that the user follows.
+ * This function only do something when the user in fact changes his photo
+ * @type {CloudFunction<DocumentSnapshot>}
+ */
+exports.onUpdateUser = functions.firestore
+    .document('/users/{userId}')
+    .onCreate(async (change, context) => {
+        const userId = context.params.userId;
+        const previousUser = change.before.data();
+        const newUser = change.after.data();
+
+        if (newUser.photoURL !== previousUser.photoURL) {
+            const newPhotoUrl = newUser.photoURL;
+
+            const politicosSeguidosUsuario = await admin
+                .firestore()
+                .collection('politicos_seguidos')
+                .doc(userId)
+                .collection('politicosSeguidos')
+                .get();
+            
+            politicosSeguidosUsuario.forEach(async (politico) => {
+                await admin
+                    .firestore()
+                    .collection('usuarios_seguindo')
+                    .doc(politico.id)
+                    .collection('usuariosSeguindo')
+                    .doc(userId)
+                    .update({ "photoUrl": newPhotoUrl });
+            });
+        }
+    })


### PR DESCRIPTION
<!--  Obrigado pela sua contribuição !-->

**O que esse PR faz / por que precisamos dele?**:
Quando um usuário atualiza a sua imagem de perfil atualizamos todas as imagens deste usuario nas coleções usuarios_seguindo de cada politico que este usuário segue

**Quais issue(s) esse PR corrige?**:
Fixes #225 

